### PR TITLE
feat: 优化好友操作配置，增加操作类型启用控制

### DIFF
--- a/src/friend.js
+++ b/src/friend.js
@@ -40,6 +40,16 @@ const HELP_ONLY_WITH_EXP = true; // !!!无效，暂时无法判断。有修复�
 // 配置: 是否启用放虫放草功能
 const ENABLE_PUT_BAD_THINGS = false;  // 无效！！！开启后会多次访问朋友导致被拉黑 请勿更改暂时关闭放虫放草功能
 
+// 配置: 启用的操作类型 (如果全部为 false，则不处理任何操作)
+const ENABLED_OPERATIONS = {
+    steal: true,      // 偷菜 (10008)
+    water: false,      // 浇水 (10007)
+    weed: false,       // 除草 (10005)
+    bug: false,        // 除虫 (10006)
+    putWeed: false,   // 放草 (10003)
+    putBug: false,    // 放虫 (10004)
+};
+
 // ============ 好友 API ============
 
 async function getAllFriends() {
@@ -353,7 +363,7 @@ async function visitFriend(friend, totalActions, myGid) {
     const actions = [];
 
     // 帮助操作: 只在有经验时执行 (如果启用了 HELP_ONLY_WITH_EXP)
-    if (status.needWeed.length > 0) {
+    if (ENABLED_OPERATIONS.weed && status.needWeed.length > 0) {
         const shouldHelp = !HELP_ONLY_WITH_EXP || canGetExp(10005);  // 10005=除草
         if (shouldHelp) {
             let ok = 0;
@@ -365,7 +375,7 @@ async function visitFriend(friend, totalActions, myGid) {
         }
     }
 
-    if (status.needBug.length > 0) {
+    if (ENABLED_OPERATIONS.bug && status.needBug.length > 0) {
         const shouldHelp = !HELP_ONLY_WITH_EXP || canGetExp(10006);  // 10006=除虫
         if (shouldHelp) {
             let ok = 0;
@@ -377,7 +387,7 @@ async function visitFriend(friend, totalActions, myGid) {
         }
     }
 
-    if (status.needWater.length > 0) {
+    if (ENABLED_OPERATIONS.water && status.needWater.length > 0) {
         const shouldHelp = !HELP_ONLY_WITH_EXP || canGetExp(10007);  // 10007=浇水
         if (shouldHelp) {
             let ok = 0;
@@ -389,8 +399,8 @@ async function visitFriend(friend, totalActions, myGid) {
         }
     }
 
-    // 偷菜: 始终执行
-    if (status.stealable.length > 0) {
+    // 偷菜: 根据配置决定是否执行
+    if (ENABLED_OPERATIONS.steal && status.stealable.length > 0) {
         let ok = 0;
         const stolenPlants = [];
         for (let i = 0; i < status.stealable.length; i++) {
@@ -412,7 +422,7 @@ async function visitFriend(friend, totalActions, myGid) {
     }
 
     // 捣乱操作: 放虫(10004)/放草(10003)
-    if (ENABLE_PUT_BAD_THINGS && status.canPutBug.length > 0 && canOperate(10004)) {
+    if (ENABLED_OPERATIONS.putBug && ENABLE_PUT_BAD_THINGS && status.canPutBug.length > 0 && canOperate(10004)) {
         let ok = 0;
         const remaining = getRemainingTimes(10004);
         const toProcess = status.canPutBug.slice(0, remaining);
@@ -424,7 +434,7 @@ async function visitFriend(friend, totalActions, myGid) {
         if (ok > 0) { actions.push(`放虫${ok}`); totalActions.putBug += ok; }
     }
 
-    if (ENABLE_PUT_BAD_THINGS && status.canPutWeed.length > 0 && canOperate(10003)) {
+    if (ENABLED_OPERATIONS.putWeed && ENABLE_PUT_BAD_THINGS && status.canPutWeed.length > 0 && canOperate(10003)) {
         let ok = 0;
         const remaining = getRemainingTimes(10003);
         const toProcess = status.canPutWeed.slice(0, remaining);
@@ -461,7 +471,7 @@ async function checkFriends() {
         if (friends.length === 0) { log('好友', '没有好友'); return; }
 
         // 检查是否还有捣乱次数 (放虫/放草)
-        const canPutBugOrWeed = canOperate(10004) || canOperate(10003);  // 10004=放虫, 10003=放草
+        const canPutBugOrWeed = (ENABLED_OPERATIONS.putBug && canOperate(10004)) || (ENABLED_OPERATIONS.putWeed && canOperate(10003));  // 10004=放虫, 10003=放草
 
         // 分两类：有预览信息的优先访问，其他的放后面（用于放虫放草）
         const priorityFriends = [];  // 有可偷/可帮助的好友


### PR DESCRIPTION
支持在friend.js里配置各项操作开关（默认只开启偷菜）

```
// 配置: 启用的操作类型 (如果全部为 false，则不处理任何操作)
const ENABLED_OPERATIONS = {
    steal: true,      // 偷菜 (10008)
    water: false,      // 浇水 (10007)
    weed: false,       // 除草 (10005)
    bug: false,        // 除虫 (10006)
    putWeed: false,   // 放草 (10003)
    putBug: false,    // 放虫 (10004)
};
```